### PR TITLE
Improve HTML layout and styling

### DIFF
--- a/hackerservice/static/css/components.css
+++ b/hackerservice/static/css/components.css
@@ -16,6 +16,29 @@
   border-radius: 4px;
   margin-top: 0.5rem;
 }
+
+.btn-tertiary {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #95a5a6;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-top: 0.5rem;
+}
+
+.headline {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.cat-header {
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.4rem;
+  color: #34495e;
+  text-transform: uppercase;
+}
 .service-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px,1fr));
@@ -42,4 +65,50 @@
   padding: 2rem;
   margin: 2rem;
   border-radius: 8px;
+}
+
+.order-section,
+.invoice-section {
+  background: #fff;
+  padding: 2rem;
+  margin: 2rem 0;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.notice {
+  background: #e7f5ff;
+  border-left: 4px solid #3498db;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th, td {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+}
+
+th {
+  background: #f9f9f9;
+  text-align: left;
+}
+
+input,
+select,
+textarea {
+  padding: 0.4rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font: inherit;
+}
+
+label {
+  display: block;
+  margin-top: 0.5rem;
 }

--- a/hackerservice/static/css/layout.css
+++ b/hackerservice/static/css/layout.css
@@ -5,6 +5,12 @@ body {
   color: #2c3e50;
   background: #f4f4f4;
 }
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
 .site-header {
   display: flex;
   justify-content: space-between;

--- a/hackerservice/templates/base.html
+++ b/hackerservice/templates/base.html
@@ -34,7 +34,9 @@
     <div id="progress-bar" class="progress-bar"></div>
   </div>
 
-  {% block content %}{% endblock %}
+  <main class="container">
+    {% block content %}{% endblock %}
+  </main>
 
   <footer class="site-footer">
     &copy; 2025 HackerService

--- a/hackerservice/templates/services.html
+++ b/hackerservice/templates/services.html
@@ -1,38 +1,22 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>HackerService — Services</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/components.css') }}">
-</head>
-<body>
-  <header class="site-header">
-    <div class="logo">HackerService</div>
-    <nav class="main-nav">
-      <a href="{{ url_for('services.list_services') }}">Services</a>
-      <a href="{{ url_for('pages.about') }}">About</a>
-      <a href="{{ url_for('pages.contact') }}">Contact</a>
-    </nav>
-  </header>
-
-  {% for category, items in grouped.items() %}
-    <h2 class="cat-header">{{ category }}</h2>
-    <div class="service-grid">
-      {% for s in items %}
-        <article class="service-card">
-          <h3>{{ s.name }}</h3>
-          <p class="price">{{ s.price }}</p>
-          <p>{{ s.pitch }}</p>
-          <p class="coins">Coins: {{ s.coins }}</p>
-          <a class="btn-secondary"
-             href="{{ url_for('services.service_detail', slug=s.slug) }}">
-             Details / Buy
-          </a>
-        </article>
-      {% endfor %}
-    </div>
-  {% endfor %}
-</body>
-</html>
+{% extends 'base.html' %}
+{% block title %}Services — HackerService{% endblock %}
+{% block content %}
+<h1 class="headline">Available Services</h1>
+{% for category, items in grouped.items() %}
+  <h2 class="cat-header">{{ category }}</h2>
+  <div class="service-grid">
+    {% for s in items %}
+      <article class="service-card">
+        <h3>{{ s.name }}</h3>
+        <p class="price">{{ s.price }}</p>
+        <p>{{ s.pitch }}</p>
+        <p class="coins">Coins: {{ s.coins }}</p>
+        <a class="btn-secondary"
+           href="{{ url_for('services.service_detail', slug=s.slug) }}">
+           Details / Buy
+        </a>
+      </article>
+    {% endfor %}
+  </div>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- refactor services page to use base layout
- wrap page content in a centered container
- add general table and form styles
- style checkout sections and notices
- add tertiary button style

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877fe5cb510832d884b005ffff1da0c