### PR TITLE
Fix captcha flow

### DIFF
--- a/hackerservice/blueprints/pages/views.py
+++ b/hackerservice/blueprints/pages/views.py
@@ -1,6 +1,23 @@
-from flask import Blueprint, render_template, redirect, url_for
+from flask import (
+    Blueprint, render_template, redirect,
+    url_for, request, session, flash
+)
+from hackerservice.services.captcha import new_captcha, validate
 
 bp = Blueprint('pages', __name__)
+
+
+@bp.before_app_request
+def require_site_captcha():
+    """Force a CAPTCHA check for first-time visitors."""
+    if request.endpoint in (
+        'pages.captcha',
+        'static',
+        'auth.login_view',
+    ):
+        return
+    if not session.get('site_verified'):
+        return redirect(url_for('pages.captcha', next=request.url))
 
 @bp.get('/')
 def home():
@@ -13,3 +30,14 @@ def about():
 @bp.get('/contact')
 def contact():
     return render_template('contact.html')
+
+
+@bp.route('/captcha', methods=['GET', 'POST'])
+def captcha():
+    next_url = request.args.get('next') or request.form.get('next') or url_for('pages.home')
+    if request.method == 'POST':
+        if validate(request.form.get('captcha', '')):
+            session['site_verified'] = True
+            return redirect(next_url)
+        flash('Captcha incorrect.', 'error')
+    return render_template('captcha.html', captcha_img=new_captcha(), next=next_url)

--- a/hackerservice/templates/captcha.html
+++ b/hackerservice/templates/captcha.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Verify You Are Human{% endblock %}
+{% block content %}
+<section class="order-section">
+  <h2>Verification Required</h2>
+  <p>Please complete the CAPTCHA to continue.</p>
+  <form method="post">
+    <input type="hidden" name="next" value="{{ next }}">
+    <img src="{{ captcha_img }}" alt="CAPTCHA challenge" width="200" height="80"><br><br>
+    <label for="captcha-input">Enter CAPTCHA:</label><br>
+    <input id="captcha-input" type="text" name="captcha" required><br><br>
+    <button type="submit" class="btn-primary">Verify</button>
+  </form>
+</section>
+{% endblock %}

--- a/hackerservice/templates/login.html
+++ b/hackerservice/templates/login.html
@@ -7,6 +7,9 @@
   <input id="login-username" name="username" placeholder="Your username" required>
   <label for="login-password">Password</label>
   <input id="login-password" name="password" type="password" placeholder="Your password" required>
+  <img src="{{ captcha_img }}" alt="CAPTCHA challenge" width="200" height="80"><br><br>
+  <label for="captcha-input">Enter CAPTCHA:</label>
+  <input id="captcha-input" name="captcha" required>
   <button class="btn-primary" type="submit">Login</button>
 </form>
 <p>If you do not yet have credentials please contact an administrator.</p>

--- a/hackerservice/templates/service_detail.html
+++ b/hackerservice/templates/service_detail.html
@@ -12,11 +12,7 @@
     {% endfor %}
   </ul>
   <p>{{ service.pitch }}</p>
-  <p>Please complete the CAPTCHA below to confirm you are a real user.</p>
   <form method="post">
-    <img src="{{ captcha_img }}" alt="CAPTCHA challenge" width="200" height="80"><br><br>
-    <label for="captcha-input">Enter CAPTCHA:</label><br>
-    <input id="captcha-input" type="text" name="captcha" required><br><br>
     <button type="submit" class="btn-primary">Continue</button>
   </form>
   <p><a href="{{ url_for('services.list_services') }}">← Back to Services</a></p>


### PR DESCRIPTION
## Summary
- remove captcha requirement from service checkout step
- require captcha for first-time visitors via global before request
- add captcha to login page
- create dedicated captcha template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687817641264832dab3f699468be491c